### PR TITLE
disable `NoUndefinedVariables` when using relay

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ const relayRuleNames = without(graphQLValidationRuleNames,
   'ScalarLeafs',
   'ProvidedNonNullArguments',
   'KnownDirectives',
+  'NoUndefinedVariables',
 );
 
 const graphQLValidationRules = graphQLValidationRuleNames.map((ruleName) => {


### PR DESCRIPTION
possible workaround for #16 