### PR TITLE
Add option `schemaJsonFilepath` which allows set up absolute path to the graphql json file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ module.exports = {
       // Import your schema JSON here
       schemaJson: require('./schema.json'),
 
+      // OR provide absolute path to your schema JSON
+      // schemaJsonFilepath: path.resolve(__dirname, './schema.json'),
+
       // tagName is gql by default
     }]
   },
@@ -88,6 +91,9 @@ module.exports = {
       // Import your schema JSON here
       schemaJson: require('./schema.json'),
 
+      // OR provide absolute path to your schema JSON
+      // schemaJsonFilepath: path.resolve(__dirname, './schema.json'),
+
       // tagName is set for you to Relay.QL
     }]
   },
@@ -111,6 +117,9 @@ module.exports = {
 
       // Import your schema JSON here
       schemaJson: require('./schema.json'),
+
+      // OR provide absolute path to your schema JSON
+      // schemaJsonFilepath: path.resolve(__dirname, './schema.json'),
 
       // Optional, the name of the template tag, defaults to 'gql'
       tagName: 'gql'


### PR DESCRIPTION
I'm using this plugin with Atom in isomorphic app. And my webpack configuration may change/regenerate `graphql.schema.json` file on the fly.

So for me is not a good solution to provide schema object via `.eslintrc.js`. So this PR adds an ability to provide an absolute path to the graphql schema json file.

My `.eslintrc.js` with this PR looks like
```js
const path = require('path');

module.exports = {
  "env": {
    "node": true,
    "es6": true,
    "browser": true,
  },
  "parser": "babel-eslint",
  "extends": "airbnb",
  "plugins": [
    "import",
    "graphql"
  ],
  "settings": {
    "import/resolver": {
      "babel-module": {}
    }
  },
  "globals": {
    "__DEV__": true
  },
  "rules": {
    "graphql/template-strings": ['error', {
      env: 'relay',
      // schemaJson: require('./build/schema.graphql.json'),
      schemaJsonFilepath: path.resolve(__dirname, './build/schema.graphql.json'),
    }]
  }
};
```

PS. Another useful PR to `babel-relay-plugin` for isomorphic apps: https://github.com/facebook/relay/pull/1436 