### PR TITLE
Fix required fs import for `schemaJsonFilepath` option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import {
   parse,
   validate,


### PR DESCRIPTION
Sorry for the inconvenience. I don't know how it happens, but I somehow missed `import fs from 'fs';` in my previous PR https://github.com/apollostack/eslint-plugin-graphql/pull/20 (which on npm right now). 😇

<img width="634" alt="screen shot 2016-11-04 at 10 42 40" src="https://cloud.githubusercontent.com/assets/1946920/19994782/b9c85b12-a27b-11e6-83ef-1372f06ed830.png">
<img width="622" alt="screen shot 2016-11-04 at 10 42 29" src="https://cloud.githubusercontent.com/assets/1946920/19994784/bb531bc0-a27b-11e6-8d73-0e8ad6395419.png">


Please merge and bump new version. Thanks.
