### PR TITLE
Disable rule checking for other tagged template strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,19 +102,23 @@ const rules = {
     return {
       TaggedTemplateExpression(node) {
         const tagNameSegments = tagName.split('.').length;
-        if (tagNameSegments === 1) {
-          // Check for single identifier, like 'gql'
-          if (node.tag.type === 'Identifier' && node.tag.name !== tagName) {
+        if (node.tag.type === 'Identifier') {
+          if (tagNameSegments === 1) {
+            if (node.tag.name !== tagName) {
+              return;
+            }
+          }else if(tagNameSegments === 2){
             return;
           }
-        } else if (tagNameSegments === 2){
-          // Check for dotted identifier, like 'Relay.QL'
-          if (node.tag.type === 'MemberExpression' &&
-              node.tag.object.name + '.' + node.tag.property.name !== tagName) {
+        }else if( node.tag.type === 'MemberExpression'){
+          if (tagNameSegments === 1) {
             return;
+          }else if(tagNameSegments === 2){
+            if (node.tag.object.name + '.' + node.tag.property.name !== tagName) {
+              return;
+            }
           }
         }
-
         let text;
         try {
           text = replaceExpressions(node.quasi, context, env);

--- a/src/index.js
+++ b/src/index.js
@@ -103,11 +103,15 @@ const rules = {
       TaggedTemplateExpression(node) {
         const tagNameSegments = tagName.split('.').length;
         if (node.tag.type === 'Identifier') {
+          //if the developer uses a single identifier : gql`...`
           if (tagNameSegments === 1) {
+            //check if it's different than the one provided in the options
             if (node.tag.name !== tagName) {
+              //skip rule checking
               return;
             }
           }else if(tagNameSegments === 2){
+            //Identifier can't be equal to a MemberExpression
             return;
           }
         }else if( node.tag.type === 'MemberExpression'){

--- a/test/makeRule.js
+++ b/test/makeRule.js
@@ -456,3 +456,34 @@ const parserOptions = {
     ]
   });
 }
+{
+  const options = [
+    { schemaJsonFilepath, tagName: 'gql' },
+  ];
+
+  ruleTester.run('different tag name', rule, {
+    valid: [
+      {
+        options,
+        parserOptions,
+        code: 'const x = test.gamma`{ nonExistentQuery }`',
+      },
+      {
+        options,
+        parserOptions,
+        code: 'const x = test.gql`{ nonExistentQuery }`',
+      },
+    ],
+    invalid: [
+      {
+        options,
+        parserOptions,
+        code: 'const x = gql`{ nonExistentQuery }`',
+        errors: [{
+          message: 'Cannot query field "nonExistentQuery" on type "RootQuery".',
+          type: 'TaggedTemplateExpression'
+        }]
+      },
+    ],
+  });
+}


### PR DESCRIPTION
I ran into this issue when using the following code:
```javascript
const StyledView = styled.View`
  background-color: ${props=> isOdd(props)};
`;
```
The linter gave me a graphql error on this.

I changed the order of checking the tagName provided in the options and the node to check the node first. I added some test cases and all of them are working.