### PR TITLE
enable linting of *.gql *.graphql when using gql tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ Code snippet taken from:  <https://leanpub.com/understandinges6/read#leanpub-aut
 
 Note: the linter rule could be extended to identify calls to various specific APIs to eliminate the need for a template literal tag, but this might just make the implementation a lot more complex for little benefit.
 
+### GraphQL literal files
+
+This plugin also lints GraphQL literal files ending on `.gql` or `.graphql`.
+In order to do so just tell eslint to check these files as well.
+
+```BASH
+eslint . --ext js,gql,graphql
+```
+
 ### Example config for Apollo
 
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -248,7 +248,7 @@ const gqlProcessor = {
     return [`${internalTag}\`${excaped}\``];
   },
   postprocess: function(messages) {
-    // Filter all messages against graphql/${Oject.keys(rules)}
+    // only report graphql-errors
     return flatten(messages).filter((message) => {
       return keys(rules).map((key) => `graphql/${key}`).includes(message.ruleId);
     })

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ const rules = {
       env,
       tagName: tagNameOption,
     } = context.options[0];
-    const filename = context.eslint.getFilename()
+    const filename = context.eslint.getFilename();
     const ext = last(filename.split('.'));
 
     // Validate and unpack schema
@@ -243,9 +243,9 @@ function strWithLen(len) {
 
 const gqlProcessor = {
   preprocess: function(text) {
-    const excaped = text.replace(/`/g, '\\`');
+    const escaped = text.replace(/`/g, '\\`');
 
-    return [`${internalTag}\`${excaped}\``];
+    return [`${internalTag}\`${escaped}\``];
   },
   postprocess: function(messages) {
     // only report graphql-errors

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ import {
 } from 'graphql';
 
 import {
+  flatten,
+  keys,
   without,
 } from 'lodash';
 
@@ -230,4 +232,26 @@ function strWithLen(len) {
   return new Array(len + 1).join( 'x' );
 }
 
-export { rules };
+const gqlProcessor = {
+    preprocess: function(text, filename) {
+        // we can not check for settings here
+        // so sadly we have to stick with a fixed tag
+        return [
+            `gql\`${text}\``,
+        ];
+    },
+    postprocess: function(messages, filename) {
+        // filter all messages against graphql/${Oject.keys(rules)}
+        return flatten(messages).filter((message) => {
+            return keys(rules).map((key) => `graphql/${key}`).includes(message.ruleId);
+        })
+    }
+}
+
+module.exports = {
+    rules,
+    processors: {
+        ".gql": gqlProcessor,
+        ".graphql": gqlProcessor
+    }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -243,7 +243,7 @@ function strWithLen(len) {
 
 const gqlProcessor = {
   preprocess: function(text) {
-    const excaped = text.replace(/`/g, '\\`')
+    const excaped = text.replace(/`/g, '\\`');
 
     return [`${internalTag}\`${excaped}\``];
   },

--- a/test/index.js
+++ b/test/index.js
@@ -5,3 +5,4 @@ require('babel-polyfill');
 
 // The tests, however, can and should be written with ECMAScript 2015.
 require('./makeRule');
+require('./makeProcessors');

--- a/test/makeProcessors.js
+++ b/test/makeProcessors.js
@@ -1,0 +1,40 @@
+import assert from 'assert';
+import {
+  includes,
+  keys,
+} from 'lodash';
+
+import { processors } from '../src';
+
+describe('processors', () => {
+  it('should define processors', () => {
+    const extensions = keys(processors);
+
+    assert(includes(extensions, '.gql'));
+    assert(includes(extensions, '.graphql'));
+  });
+
+  it('should escape backticks and append internalTag', () => {
+    const query = 'query { someValueWith` }'
+    const expected = 'ESLintPluginGraphQLFile`query { someValueWith\\` }`'
+    const preprocess = processors['.gql'].preprocess;
+    const result = preprocess(query);
+
+    assert.equal(result, expected);
+  });
+
+  it('should filter only graphql/* rules ', () => {
+    const messages = [
+      { ruleId: 'no-undef' },
+      { ruleId: 'semi' },
+      { ruleId: 'graphql/randomString' },
+      { ruleId: 'graphql/template-strings' },
+    ];
+    const expected = { ruleId: 'graphql/template-strings' };
+    const postprocess = processors['.gql'].postprocess;
+    const result = postprocess(messages);
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0].ruleId, expected.ruleId);
+  });
+});

--- a/test/makeProcessors.js
+++ b/test/makeProcessors.js
@@ -14,7 +14,7 @@ describe('processors', () => {
     assert(includes(extensions, '.graphql'));
   });
 
-  it('should escape backticks and append internalTag', () => {
+  it('should escape backticks and prepend internalTag', () => {
     const query = 'query { someValueWith` }'
     const expected = 'ESLintPluginGraphQLFile`query { someValueWith\\` }`'
     const preprocess = processors['.gql'].preprocess;


### PR DESCRIPTION
I ran into the issue where I want to lint my *.gql files so I can use graphql-tag loader for webpack.

Open points:
- I do not see any possibility to access the plugins configuration in `processors`
- I am new to eslint plugins and asking for advice regarding testing

closes #25