### PR TITLE
Fix tagname check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,12 +104,12 @@ const rules = {
         const tagNameSegments = tagName.split('.').length;
         if (tagNameSegments === 1) {
           // Check for single identifier, like 'gql'
-          if (node.tag.type === 'Identifier' && node.tag.name !== tagName) {
+          if (node.tag.type !== 'Identifier' || node.tag.name !== tagName) {
             return;
           }
         } else if (tagNameSegments === 2){
           // Check for dotted identifier, like 'Relay.QL'
-          if (node.tag.type === 'MemberExpression' &&
+          if (node.tag.type !== 'MemberExpression' ||
               node.tag.object.name + '.' + node.tag.property.name !== tagName) {
             return;
           }

--- a/test/makeRule.js
+++ b/test/makeRule.js
@@ -30,6 +30,11 @@ const parserOptions = {
         parserOptions,
         code: 'const x = gql`{ number }`',
       },
+      {
+        options,
+        parserOptions,
+        code: 'const x = segmented.TagName`height: 12px;`'
+      }
     ],
 
     invalid: [
@@ -275,6 +280,9 @@ const parserOptions = {
           }
         })
         class HelloApp extends React.Component {}
+      `,
+      `
+        const StyledComponent = css\`height: 12px;\`
       `,
       `
         HelloApp = Relay.createContainer(HelloApp, {


### PR DESCRIPTION
We're using [styled-components](https://github.com/styled-components/styled-components) and Relay in our application and eslint-plugin-babel tries to validate the content of css`...` template tags:

![eslint](https://cloud.githubusercontent.com/assets/387068/20455161/78d51466-ae55-11e6-96eb-a2e53e7a32a1.png)

The check to skip validating the tagged template contents should bail if the current node is not of the right type or the tag name doesn't match.