### PR TITLE
Support validation against multiple schemas.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib
 test/schema.json
+test/second-schema.json

--- a/README.md
+++ b/README.md
@@ -139,3 +139,27 @@ module.exports = {
   ]
 }
 ```
+
+### Additional Schemas or Tags
+
+This plugin can be used to validate against multiple schemas by identifying them with different tags. This is useful for applications interacting with multiple GraphQL systems. Additional schemas can simply be appended to the options list:
+
+```js
+module.exports = {
+  parser: "babel-eslint",
+  rules: {
+    "graphql/template-strings": ['error', {
+      env: 'apollo',
+      tagName: 'FirstGQL',
+      schemaJson: require('./schema-first.json')
+    }, {
+      env: 'relay',
+      tagName: 'SecondGQL',
+      schemaJson: require('./schema-second.json')
+    }]
+  },
+  plugins: [
+    'graphql'
+  ]
+}
+```

--- a/src/index.js
+++ b/src/index.js
@@ -61,119 +61,130 @@ const gqlFiles = ['gql', 'graphql'];
 
 const rules = {
   'template-strings'(context) {
-    const {
-      schemaJson, // Schema via JSON object
-      schemaJsonFilepath, // Or Schema via absolute filepath
-      env,
-      tagName: tagNameOption,
-    } = context.options[0];
-    const filename = context.eslint.getFilename();
-    const ext = last(filename.split('.'));
+    const optionGroup = context.options[0];
+    const {schema, env, tagName} = parseOptions(optionGroup);
+    return createRule(context, schema, env, tagName);
+  },
+};
 
-    // Validate and unpack schema
-    function initSchema(json) {
-      const unpackedSchemaJson = json.data ? json.data : json;
-      if (! unpackedSchemaJson.__schema) {
-        throw new Error('Please pass a valid GraphQL introspection query result.');
-      }
-      return buildClientSchema(unpackedSchemaJson);
-    }
+function parseOptions(optionGroup) {
+  const {
+    schemaJson, // Schema via JSON object
+    schemaJsonFilepath, // Or Schema via absolute filepath
+    env,
+    tagName: tagNameOption,
+  } = optionGroup;
 
-    function initSchemaFromFile(jsonFile) {
-      return initSchema(JSON.parse(fs.readFileSync(jsonFile, 'utf8')));
-    }
-
-    let schema;
-    if (schemaJson) {
-      schema = initSchema(schemaJson);
-    } else if(schemaJsonFilepath) {
-      schema = initSchemaFromFile(schemaJsonFilepath);
-    } else {
-      throw new Error('Must pass in `schemaJson` option with schema object '
-                    + 'or `schemaJsonFilepath` with absolute path to the json file.');
-    }
-
-    // Validate env
-    if (env && env !== 'lokka' && env !== 'relay' && env !== 'apollo') {
-      throw new Error('Invalid option for env, only `apollo`, `lokka`, and `relay` supported.')
-    }
-
-    // Validate tagName and set default
-    let tagName = null
-    if (gqlFiles.includes(ext)){
-      tagName = internalTag;
-    } else if (tagNameOption) {
-      tagName = tagNameOption;
-    } else if (env === 'relay') {
-      tagName = 'Relay.QL';
-    } else {
-      tagName = 'gql';
-    }
-
-    return {
-      TaggedTemplateExpression(node) {
-        const tagNameSegments = tagName.split('.').length;
-        if (tagNameSegments === 1) {
-          // Check for single identifier, like 'gql'
-          if (node.tag.type !== 'Identifier' || node.tag.name !== tagName) {
-            return;
-          }
-        } else if (tagNameSegments === 2){
-          // Check for dotted identifier, like 'Relay.QL'
-          if (node.tag.type !== 'MemberExpression' ||
-              node.tag.object.name + '.' + node.tag.property.name !== tagName) {
-            return;
-          }
-        } else {
-          // We don't currently support 3 segments so ignore
-          return;
-        }
-
-        let text;
-        try {
-          text = replaceExpressions(node.quasi, context, env);
-        } catch (e) {
-          if (e.message !== 'Invalid interpolation') {
-            console.log(e);
-          }
-
-          return;
-        }
-
-        // Re-implement syntax sugar for fragment names, which is technically not valid
-        // graphql
-        if ((env === 'lokka' || env === 'relay') && /fragment\s+on/.test(text)) {
-          text = text.replace('fragment', `fragment _`);
-        }
-
-        let ast;
-
-        try {
-          ast = parse(text);
-        } catch (error) {
-          context.report({
-            node,
-            message: error.message.split('\n')[0],
-            loc: locFrom(node, error),
-          });
-          return;
-        }
-
-        const rules = (env === 'relay' ? relayGraphQLValidationRules : graphQLValidationRules);
-
-        const validationErrors = schema ? validate(schema, ast, rules) : [];
-
-        if (validationErrors && validationErrors.length > 0) {
-          context.report({
-            node,
-            message: validationErrors[0].message,
-            loc: locFrom(node, validationErrors[0]),
-          });
-          return;
-        }
-      }
-    };
+  // Validate and unpack schema
+  let schema;
+  if (schemaJson) {
+    schema = initSchema(schemaJson);
+  } else if (schemaJsonFilepath) {
+    schema = initSchemaFromFile(schemaJsonFilepath);
+  } else {
+    throw new Error('Must pass in `schemaJson` option with schema object '
+                  + 'or `schemaJsonFilepath` with absolute path to the json file.');
   }
+
+  // Validate env
+  if (env && env !== 'lokka' && env !== 'relay' && env !== 'apollo') {
+    throw new Error('Invalid option for env, only `apollo`, `lokka`, and `relay` supported.')
+  }
+
+  // Validate tagName and set default
+  let tagName;
+  if (tagNameOption) {
+    tagName = tagNameOption;
+  } else if (env === 'relay') {
+    tagName = 'Relay.QL';
+  } else {
+    tagName = 'gql';
+  }
+  return {schema, env, tagName};
+}
+
+function initSchema(json) {
+  const unpackedSchemaJson = json.data ? json.data : json;
+  if (!unpackedSchemaJson.__schema) {
+    throw new Error('Please pass a valid GraphQL introspection query result.');
+  }
+  return buildClientSchema(unpackedSchemaJson);
+}
+
+function initSchemaFromFile(jsonFile) {
+  return initSchema(JSON.parse(fs.readFileSync(jsonFile, 'utf8')));
+}
+
+function templateExpressionMatchesTag(tagName, node) {
+  const tagNameSegments = tagName.split('.').length;
+  if (tagNameSegments === 1) {
+    // Check for single identifier, like 'gql'
+    if (node.tag.type !== 'Identifier' || node.tag.name !== tagName) {
+      return false;
+    }
+  } else if (tagNameSegments === 2) {
+    // Check for dotted identifier, like 'Relay.QL'
+    if (node.tag.type !== 'MemberExpression' ||
+        node.tag.object.name + '.' + node.tag.property.name !== tagName) {
+      return false;
+    }
+  } else {
+    // We don't currently support 3 segments so ignore
+    return false;
+  }
+  return true;
+}
+
+function createRule(context, schema, env, tagName) {
+  return {
+    TaggedTemplateExpression(node) {
+      if (!templateExpressionMatchesTag(tagName, node)) {
+        return;
+      }
+
+      let text;
+      try {
+        text = replaceExpressions(node.quasi, context, env);
+      } catch (e) {
+        if (e.message !== 'Invalid interpolation') {
+          console.log(e);
+        }
+        return;
+      }
+
+      // Re-implement syntax sugar for fragment names, which is technically not valid
+      // graphql
+      if ((env === 'lokka' || env === 'relay') && /fragment\s+on/.test(text)) {
+        text = text.replace('fragment', `fragment _`);
+      }
+
+      let ast;
+
+      try {
+        ast = parse(text);
+      } catch (error) {
+        context.report({
+          node,
+          message: error.message.split('\n')[0],
+          loc: locFrom(node, error),
+        });
+        return;
+      }
+
+      const rules = (env === 'relay' ? relayGraphQLValidationRules : graphQLValidationRules);
+
+      const validationErrors = schema ? validate(schema, ast, rules) : [];
+
+      if (validationErrors && validationErrors.length > 0) {
+        context.report({
+          node,
+          message: validationErrors[0].message,
+          loc: locFrom(node, validationErrors[0]),
+        });
+        return;
+      }
+    },
+  };
 }
 
 function locFrom(node, error) {

--- a/test/makeRule.js
+++ b/test/makeRule.js
@@ -4,6 +4,7 @@ import schemaJson from './schema.json';
 import path from 'path';
 
 const schemaJsonFilepath = path.resolve(__dirname, './schema.json');
+const secondSchemaJsonFilepath = path.resolve(__dirname, './second-schema.json');
 
 // Init rule
 
@@ -472,5 +473,43 @@ const parserOptions = {
         }]
       }
     ]
+  });
+}
+
+{
+  const options = [
+    { schemaJsonFilepath, tagName: 'gql' },
+    { schemaJsonFilepath: secondSchemaJsonFilepath, tagName: 'swapi' },
+  ];
+
+  ruleTester.run('validates multiple schemas correctly', rule, {
+    valid: [
+      {
+        options,
+        parserOptions,
+        code: [
+          'const x = gql`{ number, sum(a: 1, b: 1) }`;',
+          'const y = swapi`{ hero(episode: NEWHOPE) { id, name } }`;',
+        ].join('\n'),
+      },
+    ],
+
+    invalid: [
+      {
+        options,
+        parserOptions,
+        code: [
+          'const x = swapi`{ number, sum(a: 1, b: 1) }`;',
+          'const y = gql`{ hero(episode: NEWHOPE) { id, name } }`;',
+        ].join('\n'),
+        errors: [{
+          message: 'Cannot query field "number" on type "Query".',
+          type: 'TaggedTemplateExpression',
+        }, {
+          message: 'Cannot query field "hero" on type "RootQuery".',
+          type: 'TaggedTemplateExpression',
+        }],
+      },
+    ],
   });
 }

--- a/test/second-schema.graphql
+++ b/test/second-schema.graphql
@@ -1,0 +1,34 @@
+schema {
+  query: Query
+}
+
+enum Episode { NEWHOPE, EMPIRE, JEDI }
+
+interface Character {
+  id: String!
+  name: String
+  friends: [Character]
+  appearsIn: [Episode]
+}
+
+type Human implements Character {
+  id: String!
+  name: String
+  friends: [Character]
+  appearsIn: [Episode]
+  homePlanet: String
+}
+
+type Droid implements Character {
+  id: String!
+  name: String
+  friends: [Character]
+  appearsIn: [Episode]
+  primaryFunction: String
+}
+
+type Query {
+  hero(episode: Episode): Character
+  human(id: String!): Human
+  droid(id: String!): Droid
+}


### PR DESCRIPTION
This is a backwards-compatible change which supports multiple option groups being passed in. Tags must be unique and can refer to different schemas.

This is useful for codebases that interact with multiple GraphQL endpoints. In our case, we have multiple backend services exposing their own GraphQL schemas, and this allows us to lint their usage via backend-specific tags.

For example:

```js
const FooQuery = Foo.gql`{ foos(first: 10) { id } }`;
const BarQuery = Bar.gql`{ bars(last: 10) { name } }`;
```

via the configuration:
```js
module.exports = {
  "parser": "babel-eslint",
  "rules": {
    "graphql/template-strings": ['error', {
      env: 'apollo',
      tagName: 'Foo.gql',
      schemaJson: require('./foo-schema.json')
    }, {
      env: 'relay',
      tagName: 'Bar.gql',
      schemaJson: require('./bar-schema.json')
    }]
  },
  plugins: [
    'graphql'
  ]
}
```

If apollostack/eslint-plugin-graphql#26 and apollostack/eslint-plugin-graphql#28 can be merged in first, I'd be happy to rebase this against those changes.