### PR TITLE
Taking into account Apollo fragment interpolation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -261,7 +261,7 @@ function replaceExpressions(node, context, env) {
 
     chunks.push(chunk);
 
-    if (env === 'apollo') {
+    if (!env || env === 'apollo') {
       // In Apollo, interpolation is only valid outside top-level structures like `query` or `mutation`.
       // We'll check to make sure there's an equivalent set of opening and closing brackets, otherwise
       // we're attempting to do an invalid interpolation.
@@ -294,7 +294,7 @@ function replaceExpressions(node, context, env) {
         // Ellipsis cancels out extra characters
         const placeholder = strWithLen(nameLength);
         chunks.push('...' + placeholder);
-      } else if (env === 'apollo') {
+      } else if (!env || env === 'apollo') {
         // In Apollo, fragment interpolation is only valid outside of brackets
         // Since we don't know what we'd interpolate here (that occurs at runtime),
         // we're not going to do anything with this interpolation.

--- a/src/index.js
+++ b/src/index.js
@@ -257,12 +257,24 @@ function replaceExpressions(node, context, env) {
 
   node.quasis.forEach((element, i) => {
     const chunk = element.value.cooked;
+    const value = node.expressions[i];
 
     chunks.push(chunk);
 
-    if (!element.tail) {
-      const value = node.expressions[i];
+    if (env === 'apollo') {
+      // In Apollo, interpolation is only valid outside top-level structures like `query` or `mutation`.
+      // We'll check to make sure there's an equivalent set of opening and closing brackets, otherwise
+      // we're attempting to do an invalid interpolation.
+      if ((chunk.split('{').length - 1) !== (chunk.split('}').length - 1)) {
+        context.report({
+          node: value,
+          message: 'Invalid interpolation - fragment interpolation must occur outside of the brackets.',
+        });
+        throw new Error('Invalid interpolation');
+      }
+    }
 
+    if (!element.tail) {
       // Preserve location of errors by replacing with exactly the same length
       const nameLength = value.end - value.start;
 
@@ -282,6 +294,10 @@ function replaceExpressions(node, context, env) {
         // Ellipsis cancels out extra characters
         const placeholder = strWithLen(nameLength);
         chunks.push('...' + placeholder);
+      } else if (env === 'apollo') {
+        // In Apollo, fragment interpolation is only valid outside of brackets
+        // Since we don't know what we'd interpolate here (that occurs at runtime),
+        // we're not going to do anything with this interpolation.
       } else {
         // Invalid interpolation
         context.report({

--- a/test/makeRule.js
+++ b/test/makeRule.js
@@ -45,7 +45,12 @@ const parserOptions = {
         options,
         parserOptions,
         code: 'const x = gql.segmented`height: 12px;`'
-      }
+      },
+      {
+        options,
+        parserOptions,
+        code: 'const x = gql`{ number } ${x}`',
+      },
     ],
 
     invalid: [
@@ -65,6 +70,17 @@ const parserOptions = {
         errors: [{
           message: 'Cannot query field "nonExistentQuery" on type "RootQuery".',
           type: 'TaggedTemplateExpression'
+        }]
+      },
+      {
+        options,
+        parserOptions,
+        code: 'const x = gql`{ ${x} }`',
+        errors: [{
+          message: 'Invalid interpolation - fragment interpolation must occur outside of the brackets.',
+          type: 'Identifier',
+          line: 1,
+          column: 19
         }]
       },
     ]
@@ -110,7 +126,7 @@ const parserOptions = {
         code: 'const x = myGraphQLTag`{ ${x} }`',
         errors: [{
           type: 'Identifier',
-          message: 'Invalid interpolation - not a valid fragment or variable.'
+          message: 'Invalid interpolation - fragment interpolation must occur outside of the brackets.'
         }]
       },
     ]
@@ -127,7 +143,7 @@ const parserOptions = {
       {
         options,
         parserOptions,
-        code: 'const x = gql`{ number } ${SomeFragment}`',
+        code: 'const x = gql`{ number } ${x}`',
       },
     ],
 
@@ -288,6 +304,29 @@ const parserOptions = {
           type: 'TaggedTemplateExpression',
           line: 7,
           column: 19
+        }]
+      },
+      {
+        options,
+        parserOptions,
+        code: `
+          client.query(gql\`
+            {
+              allFilms {
+                films {
+                  \${filmInfo}
+                }
+              }
+            }
+          \`).then(result => {
+            console.log(result.allFilms.films);
+          });
+        `,
+        errors: [{
+          message: 'Invalid interpolation - not a valid fragment or variable.',
+          type: 'Identifier',
+          line: 6,
+          column: 21
         }]
       },
     ]

--- a/test/makeRule.js
+++ b/test/makeRule.js
@@ -49,7 +49,6 @@ const parserOptions = {
     ],
 
     invalid: [
-
       {
         options,
         parserOptions,
@@ -66,15 +65,6 @@ const parserOptions = {
         errors: [{
           message: 'Cannot query field "nonExistentQuery" on type "RootQuery".',
           type: 'TaggedTemplateExpression'
-        }]
-      },
-      {
-        options,
-        parserOptions,
-        code: 'const x = gql`{ ${x} }`',
-        errors: [{
-          message: 'Invalid interpolation - not a valid fragment or variable.',
-          type: 'Identifier'
         }]
       },
     ]
@@ -125,6 +115,43 @@ const parserOptions = {
       },
     ]
   });
+}
+
+{
+  const options = [
+    { schemaJson, env: 'apollo' },
+  ];
+
+  ruleTester.run('apollo', rule, {
+    valid: [
+      {
+        options,
+        parserOptions,
+        code: 'const x = gql`{ number } ${SomeFragment}`',
+      },
+    ],
+
+    invalid: [
+      {
+        options,
+        parserOptions,
+        code: 'const x = gql`query { ${x} }`',
+        errors: [{
+          message: 'Invalid interpolation - fragment interpolation must occur outside of the brackets.',
+          type: 'Identifier'
+        }]
+      },
+      {
+        options,
+        parserOptions,
+        code: 'const x = gql`query }{ ${x}`',
+        errors: [{
+          message: 'Syntax Error GraphQL (1:7) Expected {, found }',
+          type: 'TaggedTemplateExpression'
+        }]
+      }
+    ],
+  })
 }
 
 {


### PR DESCRIPTION
This PR is attempting to resolve #29.

In Apollo, fragment interpolation is now valid within the `gql` TaggedTemplateLiteral, but only outside of top-level structures like `query` or `mutation`. In other clients like Lokka and Relay, fragment interpolation actually results in a document substitution, but in Apollo this gets evaluated at runtime, so we only need to validate the location of the fragment interpolation.

We'll do this by evaluating two things:

1.  Making sure that an error isn't thrown when a valid interpolation is found
2. Throwing an error when an invalid interpolation _is_ found
In Apollo, fragment interpolation is invalid inside of query structures, so a document like this should fail:
```js
gql`query { someField ${SomeFragment} }`
```

NOTE: the evaluation strategy for checking to see if we're outside of a structure is naively evaluating the number of open and closing brackets, not whether or not they're matching. this means that 
```js
gql`query }{ ${SomeFragment}`
```
won't throw an error for invalid interpolation (but the graphql parser itself will throw an error on the invalid document structure). this just seemed easier to do.

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] ~~Update CHANGELOG.md with your change~~ (omitted because I'm not fully sure I should be doing this)
- [ ] ~~Add your name and email to the AUTHORS file (optional)~~ (omitted because this file does not exist)
- [ ] ~~If this was a change that affects the external API, update the docs and post a link to the PR in the discussion~~ (omitted because it does not change an external API)

## Steps to Reproduce
Recently, [graphql-fragments](https://github.com/apollostack/graphql-fragments#no-need-to-pass-xfragments-around-in-a-fragments-option-to-watchquery-graphql-etc) was deprecated and its functionality baked into `graphql-tag` itself, allowing one to interpolate fragments directly into queries themselves, like so:
```js
gql`
  query {
    someField
    ...SomeFragment
  }
  ${SomeFragment}
`
```
However, `eslint-plugin-graphql` will report this as a warning / error because interpolation was previously not valid in `gql` queries for the Apollo client.