### PR TITLE
Add support for custom selection of validators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,56 @@ module.exports = {
   ]
 }
 ```
+
+### Selecting Validation Rules
+
+GraphQL validation rules can be configured in the eslint rule's configuration using the `validators` setting. The default selection depends on the `env` setting. If no `env` is specified, all rules are enabled by default.
+
+The `validators` setting can be set either to a list of specific validator names or to the special value `"all"`.
+
+```js
+module.exports = {
+  parser: "babel-eslint",
+  rules: {
+    "graphql/template-strings": ['error', {
+      env: 'apollo',
+      validators: 'all',
+      tagName: 'FirstGQL',
+      schemaJson: require('./schema-first.json')
+    }, {
+      validators: ['FieldsOnCorrectType'],
+      tagName: 'SecondGQL',
+      schemaJson: require('./schema-second.json')
+    }]
+  },
+  plugins: [
+    'graphql'
+  ]
+}
+```
+
+The full list of available validators is:
+  - `ArgumentsOfCorrectType`
+  - `DefaultValuesOfCorrectType`
+  - `FieldsOnCorrectType`
+  - `FragmentsOnCompositeTypes`
+  - `KnownArgumentNames`
+  - `KnownDirectives` (*disabled by default in `relay`*)
+  - `KnownFragmentNames` (*disabled by default in `apollo`, `lokka`, and `relay`*)
+  - `KnownTypeNames`
+  - `LoneAnonymousOperation`
+  - `NoFragmentCycles`
+  - `NoUndefinedVariables` (*disabled by default in `relay`*)
+  - `NoUnusedFragments` (*disabled by default in `apollo`, `lokka`, and `relay`*)
+  - `NoUnusedVariables`
+  - `OverlappingFieldsCanBeMerged`
+  - `PossibleFragmentSpreads`
+  - `ProvidedNonNullArguments` (*disabled by default in `relay`*)
+  - `ScalarLeafs` (*disabled by default in `relay`*)
+  - `UniqueArgumentNames`
+  - `UniqueFragmentNames`
+  - `UniqueInputFieldNames`
+  - `UniqueOperationNames`
+  - `UniqueVariableNames`
+  - `VariablesAreInputTypes`
+  - `VariablesInAllowedPosition`

--- a/src/index.js
+++ b/src/index.js
@@ -62,11 +62,17 @@ const rules = {
               ],
             },
             validators: {
-              type: 'array',
-              uniqueItems: true,
-              items: {
-                enum: allGraphQLValidatorNames,
-              },
+              oneOf: [{
+                type: 'array',
+                uniqueItems: true,
+                items: {
+                  enum: allGraphQLValidatorNames,
+                },
+              }, {
+                enum: [
+                  'all',
+                ],
+              }],
             },
             tagName: {
               type: 'string',
@@ -143,8 +149,14 @@ function parseOptions(optionGroup) {
     tagName = 'gql';
   }
 
+  // The validator list may be:
+  //    The string 'all' to use all rules.
+  //    An array of rule names.
+  //    null/undefined to use the default rule set of the environment, or all rules.
   let validatorNames;
-  if (validatorNamesOption) {
+  if (validatorNamesOption === 'all') {
+    validatorNames = allGraphQLValidatorNames;
+  } else if (validatorNamesOption) {
     validatorNames = validatorNamesOption;
   } else {
     validatorNames = envGraphQLValidatorNames[env] || allGraphQLValidatorNames;

--- a/src/index.js
+++ b/src/index.js
@@ -234,6 +234,9 @@ function handleTemplateTag(node, context, schema, env) {
 }
 
 function locFrom(node, error) {
+  if (!error.locations || !error.locations.length) {
+    return;
+  }
   const location = error.locations[0];
 
   let line;

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import {
   parse,
   validate,
   buildClientSchema,
+  specifiedRules as allGraphQLValidators,
 } from 'graphql';
 
 import {
@@ -13,32 +14,7 @@ import {
   without,
 } from 'lodash';
 
-const allGraphQLValidatorNames = [
-  'ArgumentsOfCorrectType',
-  'DefaultValuesOfCorrectType',
-  'FieldsOnCorrectType',
-  'FragmentsOnCompositeTypes',
-  'KnownArgumentNames',
-  'KnownDirectives',
-  'KnownFragmentNames',
-  'KnownTypeNames',
-  'LoneAnonymousOperation',
-  'NoFragmentCycles',
-  'NoUndefinedVariables',
-  'NoUnusedFragments',
-  'NoUnusedVariables',
-  'OverlappingFieldsCanBeMerged',
-  'PossibleFragmentSpreads',
-  'ProvidedNonNullArguments',
-  'ScalarLeafs',
-  'UniqueArgumentNames',
-  'UniqueFragmentNames',
-  'UniqueInputFieldNames',
-  'UniqueOperationNames',
-  'UniqueVariableNames',
-  'VariablesAreInputTypes',
-  'VariablesInAllowedPosition',
-];
+const allGraphQLValidatorNames = allGraphQLValidators.map(rule => rule.name);
 
 // Map of env name to list of rule names.
 const envGraphQLValidatorNames = {

--- a/src/index.js
+++ b/src/index.js
@@ -14,38 +14,38 @@ import {
 } from 'lodash';
 
 const graphQLValidationRuleNames = [
-  'UniqueOperationNames',
-  'LoneAnonymousOperation',
-  'KnownTypeNames',
-  'FragmentsOnCompositeTypes',
-  'VariablesAreInputTypes',
-  'ScalarLeafs',
-  'FieldsOnCorrectType',
-  'UniqueFragmentNames',
-  //'KnownFragmentNames', -> any interpolation
-  //'NoUnusedFragments', -> any standalone fragment
-  'PossibleFragmentSpreads',
-  'NoFragmentCycles',
-  'UniqueVariableNames',
-  'NoUndefinedVariables',
-  'NoUnusedVariables',
-  'KnownDirectives',
-  'KnownArgumentNames',
-  'UniqueArgumentNames',
   'ArgumentsOfCorrectType',
-  'ProvidedNonNullArguments',
   'DefaultValuesOfCorrectType',
-  'VariablesInAllowedPosition',
+  'FieldsOnCorrectType',
+  'FragmentsOnCompositeTypes',
+  'KnownArgumentNames',
+  'KnownDirectives',
+  // 'KnownFragmentNames', -> any interpolation
+  'KnownTypeNames',
+  'LoneAnonymousOperation',
+  'NoFragmentCycles',
+  'NoUndefinedVariables',
+  // 'NoUnusedFragments', -> any standalone fragment
+  'NoUnusedVariables',
   'OverlappingFieldsCanBeMerged',
+  'PossibleFragmentSpreads',
+  'ProvidedNonNullArguments',
+  'ScalarLeafs',
+  'UniqueArgumentNames',
+  'UniqueFragmentNames',
   'UniqueInputFieldNames',
+  'UniqueOperationNames',
+  'UniqueVariableNames',
+  'VariablesAreInputTypes',
+  'VariablesInAllowedPosition',
 ];
 
 // Omit these rules when in Relay env
 const relayRuleNames = without(graphQLValidationRuleNames,
-  'ScalarLeafs',
-  'ProvidedNonNullArguments',
   'KnownDirectives',
   'NoUndefinedVariables',
+  'ProvidedNonNullArguments',
+  'ScalarLeafs',
 );
 
 const graphQLValidationRules = graphQLValidationRuleNames.map((ruleName) => {

--- a/test/makeRule.js
+++ b/test/makeRule.js
@@ -189,7 +189,7 @@ const parserOptions = {
       // `,
       `
         const query = gql\`
-          query sumNow($a: Int, $b: Int) {
+          query sumNow($a: Int!, $b: Int!) {
             sum(a: $a, b: $b)
           }
         \`;

--- a/test/schema.graphql
+++ b/test/schema.graphql
@@ -27,7 +27,7 @@ type User {
 type RootQuery {
   number: Int
   allFilms: AllFilmsObj
-  sum(a: Int, b: Int): Int
+  sum(a: Int!, b: Int!): Int!
   greetings: Greetings
 }
 


### PR DESCRIPTION
This adds support for configurable selection of GraphQL validators.

The addition is fully backwards-compatible for configurations that specified a value for `env`.

For configurations that did not set `env`, all validators are now enabled by default. This is a slight change because `KnownFragmentNames` and `NoUnusedFragments` had been disabled entirely for reasons that appear specific to Lokka.

Resolves apollostack/eslint-plugin-graphql#10 