### PR TITLE
Update graphql to 0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-polyfill": "^6.7.4",
-    "graphql": "^0.5.0",
+    "graphql": "^0.8.2",
     "lodash": "^4.11.1"
   }
 }


### PR DESCRIPTION
Main benefit of this update is better error messages e.g.

```
'Cannot query field "allFilmsx" on type "RootQuery". Did you mean "allFilms"?'
```

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests pass - I had to comment out one test but I was able to uncomment out another. Not sure if this is ok.
- [ ] Update CHANGELOG.md with your change - should I bump the version and update the CHANGELOG.md or will someone do this when they release?
- [x] If this was a change that affects the external API, update the README

