### PR TITLE
Bump graphql to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-polyfill": "^6.7.4",
-    "graphql": "^0.8.2",
+    "graphql": "^0.9.0",
     "lodash": "^4.11.1"
   }
 }


### PR DESCRIPTION
0.9.0 was released today - https://github.com/graphql/graphql-js/releases/tag/v0.9.0


